### PR TITLE
Fix: reroute images

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,14 @@
+{{/* The way this site is set up is confusing Hugo and it's not looking in its
+bundle folder for its assets.
+<!--//-->
+Longer term, we might change this from readme.md to index.md and this code can
+be removed.
+<!--//-->
+But for now, we will just reroute images saved into the CMS */}} {{ if in
+.Destination "http" }}
+<a href="{{ .Destination }}">
+  <img src="{{ .Destination }}" alt="{{ .Text }}" />
+</a>
+{{ else }}
+<img src="../{{ .Destination }}" alt="{{ .Text }}" />
+{{ end }}


### PR DESCRIPTION
The way this site is set up is confusing Hugo and it's not looking in its
bundle folder for its assets.
I think it's because it's not recognising these folders as leaf bundles because they do not contain index.md

For now, we probably want it to be readme, because we are taking advantage of the github base64 readme api to pull this content into the curriculum. Longer term, we might change this from readme.md to index.md and this code can be removed.

But for now, we will just reroute images saved into the CMS with ../

fixes #23 