### PR TITLE
Clarify PD instructions in Induction day plan

### DIFF
--- a/content/blocks/general-weekly-availability/readme.md
+++ b/content/blocks/general-weekly-availability/readme.md
@@ -11,10 +11,9 @@ objectives:
   - Share your weekly availability with your peers
 time: 10
 prep: >-
-  The [General Weekly Availability
+ Copy this [General Weekly Availability
   Spreadsheet](https://docs.google.com/spreadsheets/d/1MtWyOhoaZCsFH12PLXbAMHBS_e32nQNseVkMj2OP0Q0/copy)
-  for your cohort must have been created and shared with everyone. If no one has
-  done this yet, take the initiative and do it.
+  for your cohort and share it with everyone. If no one has done this yet, take the initiative and do it.
 
   - Someone in your cohort needs to bookmark this spreadsheet on your cohort channel in Slack.
   - Someone in your cohort also needs to do a brief post on Slack linking people to this spreadsheet.

--- a/content/blocks/general-weekly-availability/readme.md
+++ b/content/blocks/general-weekly-availability/readme.md
@@ -16,6 +16,9 @@ prep: >-
   for your cohort must have been created and shared with everyone. If no one has
   done this yet, take the initiative and do it.
 
+  - Someone in your cohort needs to bookmark this spreadsheet on your cohort channel in Slack.
+  - Someone in your cohort also needs to do a brief post on Slack linking people to this spreadsheet.
+
 
   T﻿his is one file for the cohort, not one per person.
 introduction: >-

--- a/content/blocks/set-up-a-google-sheet-to-organise-the-pairs-for-the-next-module/readme.md
+++ b/content/blocks/set-up-a-google-sheet-to-organise-the-pairs-for-the-next-module/readme.md
@@ -22,16 +22,21 @@ introduction: >-
   PS: It’s important to pair with different people in your cohort. There is more diversity, there better your professional competencies will evolve.
 exercises:
   - content: >-
-      One trainee to update the Google sheet “XXX X Rota” on the cohort drive
 
+      On the Fundamentals section of the course, you should have created a rota spreadsheet of the form “XXX X Rota”, replacing the "X"'s with the name of your region and cohort number.
+      For example, "NW 6 Rota" for the cohort in North West and cohort 6.
+      
+      Double check this rota spreadsheet is bookmarked to your cohort channel and post a link to the spreadsheet on Slack
+      
+      
+      One trainee needs to update this Google sheet “XXX X Rota” on the cohort drive
+
+
+      * Create a new tab on the spreadsheet called “Pairs Induction”
 
       * The new tab must have two columns, one with the title “Pair 1” and another for “Pair 2.” 
 
-      * The name of the tab should be “Pairs Induction”
-
       * Post a message on the cohort Slack with the shared spreadsheet and the instructions on what to do (see below)
-
-
 
 
       This tab will be the rota of the coursework.

--- a/content/blocks/set-up-a-google-sheet-to-organise-the-pairs-for-the-next-module/readme.md
+++ b/content/blocks/set-up-a-google-sheet-to-organise-the-pairs-for-the-next-module/readme.md
@@ -52,7 +52,7 @@ exercises:
       of them should be done by one person:
 
 
-      1. H﻿ow many hours of coursework has to be done in pairs? Double check the issues that have a 🫱🏿‍🫲🏽 Pairs label on this module's backlog
+      1. H﻿ow many hours of coursework have to be done in pairs? Double check the issues that have a 🫱🏿‍🫲🏽 Pairs label on this module's backlog
  
       2. Open the "General Weekly Availability" spreadsheet.
 

--- a/content/blocks/set-up-a-google-sheet-to-organise-the-pairs-for-the-next-module/readme.md
+++ b/content/blocks/set-up-a-google-sheet-to-organise-the-pairs-for-the-next-module/readme.md
@@ -52,8 +52,8 @@ exercises:
       of them should be done by one person:
 
 
-      1. H﻿ow many hours of coursework has to be done in pairs?
-
+      1. H﻿ow many hours of coursework has to be done in pairs? Double check the issues that have a 🫱🏿‍🫲🏽 Pairs label on this module's backlog
+ 
       2. Open the "General Weekly Availability" spreadsheet.
 
       3. Identify who could pair together, considering their availability.


### PR DESCRIPTION
- Get trainees to pin their availability spreadsheet in Slack
- Clarify which spreadsheets the instructions are referring to
- Refer to pairs label when setting up Pairs availability in the Induction day plan
I've added a  abel pairswith this icon 🤝 to one of the Induction issues so that it is much clearer which issues we expect the trainees to do in pairs. The volunteer team struggled to figure this out quicky last Saturday