### PR TITLE
Group work by sprint

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,5 +9,6 @@
 <section class="copy">{{.}}</section>
 {{end}}
 <h3 class="is-invisible">List of Links shown as accordions</h3>
-{{ range (.Pages.ByParam "week")}} {{ partial "details.html" . }} {{ end }} {{
-end}}
+{{ range (.Pages.GroupByParam "week")}}
+<h4>📅 Sprint {{ .Key | title }}</h4>
+{{ range .Pages }} {{ partial "details.html" . }} {{end}} {{ end }} {{ end}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,31 +7,8 @@
 <h2 class="is-invisible">List of Links to all content organised by module</h2>
 <!-- range over the fixed modules list in the site config, order them by the page param "week" and show them using this template -->
 {{ range $name := $modules }}
-<details>
-  <summary>
-    <h3>
-      <a href="{{ $baseURL }}modules/{{ $name | urlize }}">{{ $name }}</a>
-    </h3>
-  </summary>
-  <ol class="blocks">
-    {{ $moduleBlocks := (where $blocks ".Params.modules" "intersect" (slice
-    $name)) }} {{ range $moduleBlocks.ByParam "week" }}
-    <li>
-      <a href="{{ $baseURL }}{{ .RelPermalink }}">
-        <h4>{{ .Title }}</h4>
-        <p>
-          {{ range .Params.skills }}
-          <a
-            class="button button--small"
-            href="{{ $baseURL }}skills/{{. | urlize}}"
-            >{{ . }}</a
-          >
-          {{ end }}
-        </p>
-      </a>
-    </li>
-    {{ end }}
-  </ol>
-</details>
+<h3>
+  🧩 <a href="{{ $baseURL }}modules/{{ $name | urlize }}">{{ $name }} 🔗</a>
+</h3>
 
 {{ end }} {{ end }}


### PR DESCRIPTION
- group and add headings showing sprint name
- remove wonky details (which seems to expect to do this already but doesn't) from home page and link straight to module view with sprint

Fixes #26  Test on this view https://deploy-preview-38--cyf-pd.netlify.app/modules/fundamentals/


Scenario: view Sprint view on Module ✅ 
GIVEN I am on the PD Curriculum page
WHEN I click on a module (i.e Fundamentals)
THEN I can see all blocks organised per sprints

Scenario: Sprints should be shown in order ✅ 
GIVEN I am on a module page
WHEN I see the sprints
THEN they are in order from 1 to 4

Scenario: sprints should include all blocks related to it✅ 
GIVEN I am on a module page
WHEN I click on a sprint
THEN I can see the Prep blocks
AND the lessons blocks for that sprint