### PR TITLE
switch out decap for static-cms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 public
 .hugo_build.lock
 resources
+node_modules

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -18,10 +18,10 @@
     </style>
   </head>
   <body>
-    <!-- Include the script that builds the page and powers Decap CMS -->
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <!-- Include the script that builds the page-->
+    <script src="https://unpkg.com/@staticcms/app@^4.0.0/dist/static-cms-app.js"></script>
     <script>
-      CMS.registerPreviewStyle("../styles.min.css");
+      CMS.init();
     </script>
   </body>
 </html>


### PR DESCRIPTION
PD vols would like Grammarly to work in the CMS, which is not unreasonable.

Decap 3 works ok now but only on top level editable fields. Any nested block is still inert. It feels like it might be easier to switch out the CMS for this fork than get into the weeds with the grammarly API. I'm not massively inclined to learn it.

I'm opening this exploratory PR to see how it goes. Static CMS is a fork of netlify-cms, as is decap
