### PR TITLE
Fix broken link in Transferable Skills prep work

### DIFF
--- a/content/blocks/transferable-skills/index.md
+++ b/content/blocks/transferable-skills/index.md
@@ -12,7 +12,7 @@ objectives:
     skills text
 time: 40
 prep: Must have done the [prep
-  work](https://cyf-pd.netlify.app/blocks/prep-transferable-skills/readme/)
+  work](https://cyf-pd.netlify.app/blocks/prep-transferable-skills/)
 introduction: In this session we will talk about our transferable skills.
 exercises:
   - name: Brainstorming about transferable skills

--- a/content/blocks/transferable-skills/readme.md
+++ b/content/blocks/transferable-skills/readme.md
@@ -12,7 +12,7 @@ objectives:
     skills text
 time: 40
 prep: Must have done the [prep
-  work](https://cyf-pd.netlify.app/blocks/prep-transferable-skills/readme/)
+  work](https://cyf-pd.netlify.app/blocks/prep-transferable-skills/)
 introduction: In this session we will talk about our transferable skills.
 exercises:
   - name: Brainstorming about transferable skills


### PR DESCRIPTION
The prep work link in the Transferable Skills workshop (HTML/CSS Sprint 1 day plan) was broken. The original link (https://cyf-pd.netlify.app/blocks/transferable-skills/readme/) was incorrect. I removed the /readme/ part, and now the link works: https://cyf-pd.netlify.app/blocks/transferable-skills/.